### PR TITLE
fix: linux amd64 can't execute

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOARCH: amd64
+          CGO_ENABLED: 0 
           GOOS: linux
   release-darwin-386:
     name: release darwin/386


### PR DESCRIPTION
fixed #9 
根据
https://github.com/Mrs4s/six-cli/issues/9#issuecomment-662380736
编译, 可运行成功
测试下载
https://github.com/flylai/six-cli/releases/download/testt/six-cli_testt_linux_amd64.tar.gz